### PR TITLE
Simplify Installation Instructions

### DIFF
--- a/002_gptoolbox/002_gptoolbox.md
+++ b/002_gptoolbox/002_gptoolbox.md
@@ -47,6 +47,8 @@ If any of this did not work correctly, please contact the course organizer now.
 It will be difficult to continue the course without making sure this basic step
 works.
 
+Try to install it via Add-Ons Explorer Tab directly in Matlab
+![image](https://user-images.githubusercontent.com/11828200/125365486-35295e80-e329-11eb-820b-8e6f49027c77.png)
 
 ## Compiling the MEX functions (Optional)
 


### PR DESCRIPTION
Really nice work, well put together. 

IMHO we could simplify even more the instructions for students. 

I tested in Linux/Ubuntu and Windows10 and I had issues following these instructions for the installation. 
I think it is way easier to directly download from MATLAB add-ons tab. 

If not, it would be helpful to specify:
- where the users has to type those commands
- and the machine that has been tested